### PR TITLE
第2章 06 ページ遷移

### DIFF
--- a/counter_app/lib/main.dart
+++ b/counter_app/lib/main.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'test_page1.dart';
+import 'test_page2.dart';
+import 'test_page3.dart';
 
 void main() {
   runApp(const MyApp());
@@ -33,6 +35,11 @@ class MyApp extends StatelessWidget {
         useMaterial3: true,
       ),
       home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      routes: {
+        "/test1": (BuildContext context) => TestPage1(),
+        "/test2": (BuildContext context) => TestPage2(),
+        "/test3": (BuildContext context) => TestPage3(),
+      },
     );
   }
 }

--- a/counter_app/lib/main.dart
+++ b/counter_app/lib/main.dart
@@ -1,5 +1,5 @@
-import 'dart:math';
 import 'package:flutter/material.dart';
+import 'test_page1.dart';
 
 void main() {
   runApp(const MyApp());
@@ -55,94 +55,9 @@ class MyHomePage extends StatefulWidget {
   State<MyHomePage> createState() => _MyHomePageState();
 }
 
-class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
-  late AnimationController _animationController;
-  late Animation _animation;
-
-  // 再生
-  _forward() async {
-    setState(() {
-      _animationController.forward();
-    });
-  }
-
-  // 停止
-  _stop() async {
-    setState(() {
-      _animationController.stop();
-    });
-  }
-
-  // 逆再生
-  _reverse() async {
-    setState(() {
-      _animationController.reverse();
-    });
-  }
-
-  // 生成
-  @override
-  void initState() {
-    super.initState();
-    _animationController =
-        AnimationController(vsync: this, duration: const Duration(seconds: 1));
-    _animation = _animationController.drive(Tween(begin: 0.0, end: -2.0 * pi));
-  }
-
-  // 破棄
-  @override
-  void dispose() {
-    setState(() {
-      _animationController.dispose();
-      super.dispose();
-    });
-  }
-
+class _MyHomePageState extends State<MyHomePage> {
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-          child: AnimatedBuilder(
-             animation: _animation,
-        builder: (context, _) {
-          return Transform.rotate(
-              angle: _animation.value,
-              child: const Icon(Icons.cached, size: 100));
-        },
-      )),
-      // 再生、停止、逆再生ボタン
-      floatingActionButton: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          FloatingActionButton(
-            onPressed: _forward,
-            child: const Icon(Icons.arrow_forward),
-          ),
-          FloatingActionButton(
-            onPressed: _stop,
-            child: const Icon(Icons.pause),
-          ),
-          FloatingActionButton(
-            onPressed: _reverse,
-            child: const Icon(Icons.arrow_back),
-          )
-        ],
-      ),
-    );
+    return Scaffold(body: TestPage1());
   }
 }

--- a/counter_app/lib/main.dart
+++ b/counter_app/lib/main.dart
@@ -35,11 +35,6 @@ class MyApp extends StatelessWidget {
         useMaterial3: true,
       ),
       home: const MyHomePage(title: 'Flutter Demo Home Page'),
-      routes: {
-        "/test1": (BuildContext context) => TestPage1(),
-        "/test2": (BuildContext context) => TestPage2(),
-        "/test3": (BuildContext context) => TestPage3(),
-      },
     );
   }
 }
@@ -63,8 +58,51 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
+  late PageController _pageController;
+  int _selectedIndex = 0;
+
+  final _pages = [
+    TestPage1(),
+    TestPage2(),
+    TestPage3(),
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    _pageController = PageController(initialPage: _selectedIndex);
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _pageController.dispose();
+  }
+
+  void _onPageChanged(int index) {
+    setState(() {
+      _selectedIndex = index;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Scaffold(body: TestPage1());
+    return Scaffold(
+        body: PageView(
+          controller: _pageController,
+          onPageChanged: _onPageChanged,
+          children: _pages,
+        ),
+        floatingActionButton: FloatingActionButton(
+          onPressed: () {
+            _pageController.animateToPage(
+              _selectedIndex + 1,
+              duration: const Duration(milliseconds: 400),
+              curve: Curves.easeInOut,
+            );
+          },
+          tooltip: 'Next',
+          child: const Icon(Icons.arrow_forward),
+        ));
   }
 }

--- a/counter_app/lib/test_page1.dart
+++ b/counter_app/lib/test_page1.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'test_page2.dart';
+
+class TestPage1 extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Test1'),
+      ),
+      body: Center(
+        child: TextButton(
+            onPressed: () => {
+                  Navigator.of(context).push(MaterialPageRoute(
+                    builder: (context) {
+                      return TestPage2();
+                    },
+                  ))
+                },
+            child: const Text("進む", style: TextStyle(fontSize: 80))),
+      ),
+    );
+  }
+}

--- a/counter_app/lib/test_page1.dart
+++ b/counter_app/lib/test_page1.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'test_page2.dart';
 
 class TestPage1 extends StatelessWidget {
   @override
@@ -10,13 +9,7 @@ class TestPage1 extends StatelessWidget {
       ),
       body: Center(
         child: TextButton(
-            onPressed: () => {
-                  Navigator.of(context).push(MaterialPageRoute(
-                    builder: (context) {
-                      return TestPage2();
-                    },
-                  ))
-                },
+            onPressed: () => {Navigator.of(context).pushNamed('/test2')},
             child: const Text("進む", style: TextStyle(fontSize: 80))),
       ),
     );

--- a/counter_app/lib/test_page1.dart
+++ b/counter_app/lib/test_page1.dart
@@ -4,14 +4,16 @@ class TestPage1 extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Test1'),
-      ),
-      body: Center(
-        child: TextButton(
-            onPressed: () => {Navigator.of(context).pushNamed('/test2')},
-            child: const Text("進む", style: TextStyle(fontSize: 80))),
-      ),
-    );
+        appBar: AppBar(
+          title: const Text('Test1'),
+        ),
+        body: Center(
+            child: Container(
+          color: Colors.redAccent,
+          child: const Text(
+            "Test1",
+            style: TextStyle(fontSize: 80),
+          ),
+        )));
   }
 }

--- a/counter_app/lib/test_page2.dart
+++ b/counter_app/lib/test_page2.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'test_page3.dart';
+
+class TestPage2 extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(
+          title: const Text('Test2'),
+        ),
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              TextButton(
+                  onPressed: () => {
+                        Navigator.of(context)
+                            .push(MaterialPageRoute(builder: (context) {
+                          return TestPage3();
+                        }))
+                      },
+                  child: const Text("進む", style: TextStyle(fontSize: 80))),
+              TextButton(
+                  onPressed: () => {Navigator.of(context).pop()},
+                  child: const Text(
+                    "戻る",
+                    style: TextStyle(fontSize: 80),
+                  ))
+            ],
+          ),
+        ));
+  }
+}

--- a/counter_app/lib/test_page2.dart
+++ b/counter_app/lib/test_page2.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'test_page3.dart';
 
 class TestPage2 extends StatelessWidget {
   @override
@@ -13,12 +12,7 @@ class TestPage2 extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
               TextButton(
-                  onPressed: () => {
-                        Navigator.of(context)
-                            .push(MaterialPageRoute(builder: (context) {
-                          return TestPage3();
-                        }))
-                      },
+                  onPressed: () => {Navigator.of(context).pushNamed('/test3')},
                   child: const Text("進む", style: TextStyle(fontSize: 80))),
               TextButton(
                   onPressed: () => {Navigator.of(context).pop()},

--- a/counter_app/lib/test_page2.dart
+++ b/counter_app/lib/test_page2.dart
@@ -8,20 +8,12 @@ class TestPage2 extends StatelessWidget {
           title: const Text('Test2'),
         ),
         body: Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              TextButton(
-                  onPressed: () => {Navigator.of(context).pushNamed('/test3')},
-                  child: const Text("進む", style: TextStyle(fontSize: 80))),
-              TextButton(
-                  onPressed: () => {Navigator.of(context).pop()},
-                  child: const Text(
-                    "戻る",
-                    style: TextStyle(fontSize: 80),
-                  ))
-            ],
+            child: Container(
+          color: Colors.greenAccent,
+          child: const Text(
+            "Test2",
+            style: TextStyle(fontSize: 80),
           ),
-        ));
+        )));
   }
 }

--- a/counter_app/lib/test_page3.dart
+++ b/counter_app/lib/test_page3.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class TestPage3 extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(
+          title: const Text("Test3"),
+        ),
+        body: Center(
+            child: TextButton(
+                onPressed: () => {Navigator.of(context).pop()},
+                child: const Text("戻る", style: TextStyle(fontSize: 80)))));
+  }
+}

--- a/counter_app/lib/test_page3.dart
+++ b/counter_app/lib/test_page3.dart
@@ -8,8 +8,12 @@ class TestPage3 extends StatelessWidget {
           title: const Text("Test3"),
         ),
         body: Center(
-            child: TextButton(
-                onPressed: () => {Navigator.of(context).pop()},
-                child: const Text("戻る", style: TextStyle(fontSize: 80)))));
+            child: Container(
+          color: Colors.blueAccent,
+          child: const Text(
+            "Test3",
+            style: TextStyle(fontSize: 80),
+          ),
+        )));
   }
 }


### PR DESCRIPTION
## `push`, `pop`を使ったページ遷移  4b9db9997115abdc2e3035c40e821ca73bc82d08

`push`メソッドでWidgetを直接呼び出してページ遷移する。

```dart
Navigator.of(context).push(MaterialPageRoute(builder: (context) {
  return TestPage2();
})
```

`pop`メソッドで1つ前のページに戻る。

```dart
Navigator.of(context).pop()
```


## `pushNamed`を使ったページ遷移 d7aff3dd4660bf134bf59947fe8854df8bf393dc

![画面収録 2024-03-24 11 26 42](https://github.com/yuma-ito-bd/flutter-helloworld/assets/38903000/c1ac9d78-88d3-4fb7-9f85-f0f2847f3303)

`MaterialApp`の`routes`プロパティにて、パスとそれに対応するWidgetを指定する。

routesにてルーティングの設定
```dart
class MyApp extends StatelessWidget {
  @overriide
  Widget build(BuildContext context) {
    return MaterialApp(
      routes: {
        "/test1": (BuildContext context) => TestPage1(),
        "/test2": (BuildContext context) => TestPage2(),
        "/test3": (BuildContext context) => TestPage3(),
      }
    )
  }
}
```

`pushNamed`メソッドによってページ遷移する。

```dart
Navigator.of(context).pushNamed("/test2") // /test2 のパスに対応するページに遷移する
```